### PR TITLE
Fixed the wrong search method.

### DIFF
--- a/libraries/chef_mixin_nodebrew.rb
+++ b/libraries/chef_mixin_nodebrew.rb
@@ -67,9 +67,9 @@ class Chef
 
       def package_installed?(package, path = nil)
         cmd = if path
-                "cd #{path} && npm ls --depth=0 2> /dev/null | grep '#{package}'"
+                "cd #{path} && npm ls --depth=0 '#{package}' 2> /dev/null"
               else
-                "npm ls -g --depth=0 2> /dev/null | grep '#{package}'"
+                "npm ls -g --depth=0 '#{package}' 2> /dev/null"
               end
         out = nodebrew_cmd(cmd)
         out.exitstatus.zero?


### PR DESCRIPTION
Why do you revert?? 

This code has problem.

$ npm ls -g --depth=0 gulp
/usr/local/nodebrew/current/lib
└── (empty)

$ npm ls -g --depth=0 | grep gulp                                                                           
  │   │ ├── gulp-rename@1.2.0

Therefore, "npm install -g gulp" is skiped.