### PR TITLE
Change protocol to https

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,7 +1,7 @@
 # Cookbook Name:: nodebrew
 # Attributes:: default
 
-default['nodebrew']['repository'] = 'git://github.com/hokaccha/nodebrew.git'
+default['nodebrew']['repository'] = 'https://github.com/hokaccha/nodebrew.git'
 default['nodebrew']['ref']        = 'master'
 default['nodebrew']['upgrade']    = true
 default['nodebrew']['root']       = '/usr/local/lib/nodebrew'


### PR DESCRIPTION
Change to https because the unencrypted git protocol is obsolete.

https://github.blog/2021-09-01-improving-git-protocol-security-github/

```
10.51.xxx.yyy Recipe: nodebrew::default
10.51.xxx.yyy   * nodebrew[install] action install
10.51.xxx.yyy     - Install nodebrew[install]
10.51.xxx.yyy     * directory[/var/chef/cache] action create (up to date)
10.51.xxx.yyy     * git[/var/chef/cache/nodebrew] action checkout
10.51.xxx.yyy
10.51.xxx.yyy       ================================================================================
10.51.xxx.yyy       Error executing action `checkout` on resource 'git[/var/chef/cache/nodebrew]'
10.51.xxx.yyy       ================================================================================
10.51.xxx.yyy
10.51.xxx.yyy       Mixlib::ShellOut::ShellCommandFailed
10.51.xxx.yyy       ------------------------------------
10.51.xxx.yyy       Expected process to exit with [0], but received '128'
10.51.xxx.yyy       ---- Begin output of git ls-remote "git://github.com/hokaccha/nodebrew.git" "master*" ----
10.51.xxx.yyy       STDOUT:
10.51.xxx.yyy       STDERR: fatal: remote error:
10.51.xxx.yyy         The unauthenticated git protocol on port 9418 is no longer supported.
10.51.xxx.yyy       Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
10.51.xxx.yyy       ---- End output of git ls-remote "git://github.com/hokaccha/nodebrew.git" "master*" ----
10.51.xxx.yyy       Ran git ls-remote "git://github.com/hokaccha/nodebrew.git" "master*" returned 128
```