### PR TITLE
Fix error when connecting with git://

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Attributes
 
 Key        | Description             | Default
 ---        | -----------             | -------
-repository | nodebrew git repository | git://github.com/hokaccha/nodebrew.git
+repository | nodebrew git repository | https://github.com/hokaccha/nodebrew.git
 ref        | git ref                 | master
 upgrade    | sync                    | true
 root       | nodebrew root           | /usr/local/lib/nodebrew
@@ -106,7 +106,7 @@ install | install nodebrew to nodebrew_root | yes
 
 Attribute  | Description             | Default
 ---------  | -----------             | -------
-repository | nodebrew git repository | git://github.com/hokaccha/nodebrew.git
+repository | nodebrew git repository | https://github.com/hokaccha/nodebrew.git
 ref        | git ref                 | master
 upgrade    | sync                    | true
 root       | nodebrew root           | $HOME/.nodebrew

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -6,7 +6,7 @@ default_action :install
 
 attribute :repository,
   :kind_of => String,
-  :default => 'git://github.com/hokaccha/nodebrew.git'
+  :default => 'https://github.com/hokaccha/nodebrew.git'
 attribute :ref,
   :kind_of => String,
   :default => 'master'


### PR DESCRIPTION
fix:

```
**** [2022-05-13T11:42:41+09:00] ERROR: Exception handlers complete
**** Chef Client failed. 46 resources updated in 01 minutes 19 seconds
**** [2022-05-13T11:42:41+09:00] FATAL: Stacktrace dumped to /var/chef/cache/chef-stacktrace.out
**** [2022-05-13T11:42:41+09:00] FATAL: Please provide the contents of the stacktrace.out file if you file a bug report
**** [2022-05-13T11:42:41+09:00] FATAL: Mixlib::ShellOut::ShellCommandFailed: nodebrew[install] (nodebrew::default line 6) had an error: Mixlib::ShellOut::ShellCommandFailed: git[/var/chef/cache/nodebrew] (/var/chef/cache/cookbooks/nodebrew/providers/default.rb line 13) had an error: Mixlib::ShellOut::ShellCommandFailed: Expected process to exit with [0], but received '128'
**** ---- Begin output of git ls-remote "git://github.com/hokaccha/nodebrew.git" "master*" ----
**** STDOUT:
**** STDERR: fatal: remote error:
****   The unauthenticated git protocol on port 9418 is no longer supported.
**** Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
**** ---- End output of git ls-remote "git://github.com/hokaccha/nodebrew.git" "master*" ----
**** Ran git ls-remote "git://github.com/hokaccha/nodebrew.git" "master*" returned 128
```

ref: https://github.blog/2021-09-01-improving-git-protocol-security-github/

> We’re changing which keys are supported in SSH and removing unencrypted Git protocol. Only users connecting via SSH or git:// will be affected. If your Git remotes start with https://, nothing in this post will affect you. If you’re an SSH user, read on for the details and timeline.
